### PR TITLE
Added lock screen command

### DIFF
--- a/src/plugins/preferences/preferences.plugin.ts
+++ b/src/plugins/preferences/preferences.plugin.ts
@@ -220,6 +220,11 @@ export class PreferencesPlugin extends SpotterPlugin implements SpotterPluginLif
         icon: '/System/Applications/System\ Preferences.app',
         action: () => this.sleep(),
       },
+      {
+        title: 'Lock Screen Preferences',
+        icon: '/System/Applications/System\ Preferences.app',
+        action: () => this.lockScreen(),
+      },
     ];
   }
 
@@ -241,5 +246,9 @@ export class PreferencesPlugin extends SpotterPlugin implements SpotterPluginLif
 
   private async sleep() {
     await this.api.shell.execute("osascript -e 'tell app \"System Events\" to sleep'")
+  }
+
+  private async lockScreen() {
+    await this.api.shell.execute("osascript -e 'tell app \"System Events\"' -e 'tell process \"SystemUIServer\" to keystroke \"q\" using {command down, control down}' -e 'tell end'")
   }
 }


### PR DESCRIPTION
Thanks for the great work on this project! This adds a small update with the addition of the option to lock the screen (which you would normally do with `cmd+ctrl+q`) instead of just making the computer go to sleep. Let me know if this is something you'd be interested in adding to `spotter` and if there's any changes I need to make. Again, thanks for your hard work on the project!